### PR TITLE
Github Actions: Adding action to run spec

### DIFF
--- a/.github/workflows/run_rake_spec.yaml
+++ b/.github/workflows/run_rake_spec.yaml
@@ -3,8 +3,9 @@ name: Ruby
 
 on:
   push:
-    branches:
-      - "*"
+    paths:
+      - "lib/**/*"
+      - "spec/**/*"
 
 permissions:
   contents: read

--- a/.github/workflows/run_rake_spec.yaml
+++ b/.github/workflows/run_rake_spec.yaml
@@ -26,6 +26,6 @@ jobs:
         ruby-version: '2.6.3'
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: setup
-        run bundle exec bin/setup
+      run: bundle exec bin/setup
     - name: Run tests
       run: bundle exec rake spec

--- a/.github/workflows/run_rake_spec.yaml
+++ b/.github/workflows/run_rake_spec.yaml
@@ -3,6 +3,8 @@ name: Ruby
 
 on:
   push:
+    branches:
+      - "*"
 
 permissions:
   contents: read

--- a/.github/workflows/run_rake_spec.yaml
+++ b/.github/workflows/run_rake_spec.yaml
@@ -1,0 +1,28 @@
+---
+name: Ruby
+
+on:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+    # uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+      with:
+        ruby-version: '2.6.3'
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: setup
+        run bundle exec bin/setup
+    - name: Run tests
+      run: bundle exec rake spec

--- a/lib/pgdump_scrambler/config.rb
+++ b/lib/pgdump_scrambler/config.rb
@@ -3,8 +3,6 @@ require 'yaml'
 require 'erb'
 require 'config/table'
 
-# test comment
-
 module PgdumpScrambler
   class Config
     IGNORED_ACTIVE_RECORD_TABLES = %w[ar_internal_metadata schema_migrations].freeze

--- a/lib/pgdump_scrambler/config.rb
+++ b/lib/pgdump_scrambler/config.rb
@@ -3,6 +3,8 @@ require 'yaml'
 require 'erb'
 require 'config/table'
 
+# test comment
+
 module PgdumpScrambler
   class Config
     IGNORED_ACTIVE_RECORD_TABLES = %w[ar_internal_metadata schema_migrations].freeze


### PR DESCRIPTION
## 概要

テスト（`rake spec`コマンド）を実行するGithub Actionsを追加した。

## 背景

このライブラリがサポートしているRubyのバージョン（`2.6.3`）がM1マックでインストール＆実行できないため。

## 確認したこと

Github Actionsがパスすることを確認。
![image](https://github.com/OneCareerJP/pgdump_scrambler/assets/61897166/18fe0a4f-5ac8-4e67-87ad-32c3eb6e62ab)

## コメント

- Actions実行時にRubyの依存パッケージインストールにやや時間がかかるため、Github Actionsのキャッシュを使うと良さそう。ただし、現状変更頻度がとても少ないため今回は対応しなくて良い。
- folk元のリポジトリの変更を取り込んでも良いが（folk元はRuby3系）、動作確認が必要。created_atカラムの追加と一緒にやれば動作確認も一回で済みそうだが、エラー吐いた場合はデバッグにやや時間かかるか...。あと動作検証の流れも異なるため、一緒にはできないか。