### PR TITLE
Stop ignoreing `created_at` column

### DIFF
--- a/lib/pgdump_scrambler/config.rb
+++ b/lib/pgdump_scrambler/config.rb
@@ -6,7 +6,7 @@ require 'config/table'
 module PgdumpScrambler
   class Config
     IGNORED_ACTIVE_RECORD_TABLES = %w[ar_internal_metadata schema_migrations].freeze
-    IGNORED_ACTIVE_RECORD_COLUMNS = %w[id created_at updated_at].to_set.freeze
+    IGNORED_ACTIVE_RECORD_COLUMNS = %w[id updated_at].to_set.freeze
     KEY_DUMP_PATH = 'dump_path'
     KEY_TABLES = 'tables'
     KEY_EXCLUDE_TABLES = 'exclude_tables'

--- a/spec/fixtures/sample.yml
+++ b/spec/fixtures/sample.yml
@@ -4,6 +4,8 @@ tables:
   posts:
     content: sbytes
     title: sbytes
+    created_at: nop
   users:
     email: email
     name: sbytes
+    created_at: nop

--- a/spec/fixtures/sample.yml
+++ b/spec/fixtures/sample.yml
@@ -2,8 +2,8 @@
 dump_path: sample.dump
 tables:
   posts:
-    created_at: nop
     content: sbytes
+    created_at: nop
     title: sbytes
   users:
     created_at: nop

--- a/spec/fixtures/sample.yml
+++ b/spec/fixtures/sample.yml
@@ -2,10 +2,10 @@
 dump_path: sample.dump
 tables:
   posts:
+    created_at: nop
     content: sbytes
     title: sbytes
-    created_at: nop
   users:
+    created_at: nop
     email: email
     name: sbytes
-    created_at: nop

--- a/spec/pgdump_scrambler_spec.rb
+++ b/spec/pgdump_scrambler_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe PgdumpScrambler do
     dump_path: sample.dump
     tables:
       posts:
+        created_at: nop
         content: sbytes
         title: sbytes
-        created_at: nop
       users:
+        created_at: nop
         email: email
         name: sbytes
-        created_at: nop
     YAML
     path = File.expand_path('../fixtures/sample.yml',  __FILE__)
     config = PgdumpScrambler::Config.read_file(path)

--- a/spec/pgdump_scrambler_spec.rb
+++ b/spec/pgdump_scrambler_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe PgdumpScrambler do
     dump_path: sample.dump
     tables:
       posts:
-        created_at: nop
         content: sbytes
+        created_at: nop
         title: sbytes
       users:
         created_at: nop

--- a/spec/pgdump_scrambler_spec.rb
+++ b/spec/pgdump_scrambler_spec.rb
@@ -8,9 +8,11 @@ RSpec.describe PgdumpScrambler do
       posts:
         content: sbytes
         title: sbytes
+        created_at: nop
       users:
         email: email
         name: sbytes
+        created_at: nop
     YAML
     path = File.expand_path('../fixtures/sample.yml',  __FILE__)
     config = PgdumpScrambler::Config.read_file(path)


### PR DESCRIPTION
## 概要

- created_atカラムがデフォルトで無視されていたので、無視しない実装を追加した。

## 背景

マスクしたデータを用いて分析する際に、created_atカラムが必要になるケースが増えてきたため。

## 検証事項

Productionにて以下のことを確認する。
(ユーザー影響がない＆pgdump_scrabmlerのタスクがproduction環境のみでしか実行されていないため。宇田川さんと相談ずみ)。

| 大項目 | 中項目 | 結果 |
| :--- | :--- | :---: |
| | ダンプデータを正常に作成できる。| |
| | | |
| ダンプデータをローカルにロードして、Postgresコンテナを立ち上げる。 | | |
| | created_atカラムが存在する（**どうやって確認しよう**）。 | |
| | 既存のカラムが存在する（**どうやって確認しよう**）。| |
