### PR TITLE
PgdumpScrambler::from_dbで明示的にActiveRecordのキャッシュ情報を削除

### DIFF
--- a/lib/pgdump_scrambler/config.rb
+++ b/lib/pgdump_scrambler/config.rb
@@ -126,6 +126,7 @@ module PgdumpScrambler
           #   migration2: テーブルAをメモリキャッシュ(A.Whereなどをmigrationファイルに記述してしまった場合)
           #   migration3: テーブルAのcolumn1を削除
           #   ActiveRecord::Base.descendantsで取得されるテーブルAにキャッシュに乗っているcolumn1の情報が含まれてしまう
+          # 参考: https://onecareer.slack.com/archives/C04B8EGQ4DT/p1765946904698539?thread_ts=1765937049.671739&cid=C04B8EGQ4DT
           ActiveRecord::Base.descendants.each(&:reset_column_information)
 
           klasses_by_table = ActiveRecord::Base.descendants.to_h { |klass| [klass.table_name, klass] }


### PR DESCRIPTION
関連: https://github.com/OneCareerJP/onecareer/pull/9110

ocのマイグレーションファイルの一部に、Partner.whereなどActiveRecordのメソッドを実行しているものがある。この時、メソッド実行時に結果がキャッシュされるため、以下の問題が発生する

* migration1: テーブルAにcolumn1を追加
* migration2: テーブルAをメモリキャッシュ(A.Whereなどをmigrationファイルに記述してしまった場合)
* migration3: テーブルAのcolumn1を削除

この後にpgdumpをする際、ActiveRecord::Base.descendants(PR差分の少し下で実行されている)で取得されるテーブルAにキャッシュに乗っているcolumn1の情報が含まれてしまう。そのため、ocのpgdump_scrambler.ymlでcolumn1: nop を削除しても、RAILS_ENV=test bundle exec rails db:normalize_schema で復活してしまい、OCのCIが落ちてしまう。

キャッシュされたカラム情報を使わないようにすることで対応
なお、キャッシュが削除されても、その際はテーブル情報を再度DBから取得するため、キャッシュ削除のリスクは特にない